### PR TITLE
Update return type to match the latest change on KHT

### DIFF
--- a/src/MultipleLangRegexParser.php
+++ b/src/MultipleLangRegexParser.php
@@ -48,7 +48,7 @@ class MultipleLangRegexParser implements RawClippingParser
         $isHighlight = preg_match(self::HIGHLIGHT_TRANSLATIONS_REGEX,$matchesLine[0][1]);
         preg_match_all(self::LOCATION_REGEX, $matchesLine[0][1], $location);
         preg_match_all(self::MONTH_DAY_REGEX, $matchesLine[0][1], $monthDay);
-        $type = $isHighlight ? self::HIGHLIGHT : false;
+        $type = $isHighlight ? self::HIGHLIGHT : 'other';
         $publicationTitle = !empty($matches[2][0])?$matches[2][0]: $matches[4][0];
         $publicationAuthor = !empty($matches[3][0])?$matches[3][0]: "unknown";
         $publicationTitle = Bom::remove($publicationTitle);

--- a/src/MultipleLangRegexParser.php
+++ b/src/MultipleLangRegexParser.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace KHTMultiRegexParser;
 
 use DateTime;
+use KindleHighlightTosser\Application\Clipping;
 use KindleHighlightTosser\Infrastructure\Support\Bom;
 use KindleHighlightTosser\Infrastructure\Parser\MyClippings\RawClippingParser;
 use KindleHighlightTosser\Infrastructure\Parser\MyClippings\ParsedRawClipping;
@@ -35,7 +36,7 @@ class MultipleLangRegexParser implements RawClippingParser
     private $minute;
     private $second;
 
-    public function execute(string $clippingContent): ParsedRawClipping
+    public function execute(string $clippingContent): Clipping
     {
         preg_match_all(self::FIX_PARTS_REGEX, $clippingContent, $matches);
 
@@ -68,12 +69,11 @@ class MultipleLangRegexParser implements RawClippingParser
 
         $content = Bom::remove($matches[10][0]);
 
-        return new ParsedRawClipping(
+        return new Clipping(
             $type,
             $content,
             $publicationTitle,
             $publicationAuthor,
-            $locationType,
             (int)$locationFrom,
             (int)$locationTo,
             $dateTime->format('U')


### PR DESCRIPTION
The return type was changed on KHT, and now it is expected to return a `Clipping` and not an intermediary `ParsedRawClipping`. This PR makes that compatibility change.

Because the type is expected to be a string, the fallback value was changed too.